### PR TITLE
Updates for core20 and gnome-3-38

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,7 +13,7 @@ description: |
 
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict
-base: core18
+base: core20
 
 slots:
   # for GtkApplication registration
@@ -24,7 +24,7 @@ slots:
 
 apps:
   gnome-font-viewer:
-    extensions: [gnome-3-34]
+    extensions: [gnome-3-38]
     command: usr/bin/gnome-font-viewer
     plugs:
       - home
@@ -34,32 +34,24 @@ parts:
   gnome-font-viewer:
     source: https://gitlab.gnome.org/GNOME/gnome-font-viewer.git
     source-type: git
-    source-branch: gnome-3-34
+    source-branch: gnome-41
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version $(git describe --tags --abbrev=10)
-    override-build: |
-      snapcraftctl build
-      mkdir -p $SNAPCRAFT_PART_INSTALL/meta/gui/
-      cp snapbuild/src/org.gnome.font-viewer.desktop $SNAPCRAFT_PART_INSTALL/meta/gui/
     plugin: meson
+    meson-version: 0.59.2
     meson-parameters: [--prefix=/usr]
     organize:
       snap/gnome-font-viewer/current/usr: usr
-    build-packages:
-      - gettext
-      - itstool
-      - libfontconfig1-dev
-      - libfreetype6-dev
 
   # Find files provided by the base and platform snap and ensure they aren't
   # duplicated in this snap
   cleanup:
     after: [gnome-font-viewer]
     plugin: nil
-    build-snaps: [core18, gtk-common-themes, gnome-3-34-1804]
+    build-snaps: [core20, gtk-common-themes, gnome-3-38-2004]
     override-prime: |
       set -eux
-      for snap in "core18" "gtk-common-themes" "gnome-3-34-1804"; do
+      for snap in "core20" "gtk-common-themes" "gnome-3-38-2004"; do
         cd "/snap/$snap/current" && find . -type f,l -name *.so.* -exec rm -f "$SNAPCRAFT_PRIME/{}" \;
       done


### PR DESCRIPTION

## Description

- updated core and base
- removed unnecessary build-packages
- pin'd meson version to fix ftbfs issue
- removed unnecessary override-build section

## Type of change

Please check only the options that are relevant.

- [X] General Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Built it locally and tested in an updated jammy vm.