### PR TITLE
Update gnome-font-viewer to 44.0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,7 +34,7 @@ parts:
   gnome-font-viewer:
     source: https://gitlab.gnome.org/GNOME/gnome-font-viewer.git
     source-type: git
-    source-tag: '42.0'
+    source-tag: '44.0'
     parse-info: [usr/share/metainfo/org.gnome.font-viewer.appdata.xml]
     override-pull: |
       craftctl default


### PR DESCRIPTION
# Pull Request Template

## Description

We needed to update the gnome42-2204-sdk first to include gtk 4.10 and libadwaita 1.2 but that has been done.

Fixes # (issue)

## Type of change

Please check only the options that are relevant.

- [ ] General Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Built successfully on Github
- Installed and ran successfully

**Test Configuration**:

* OS (please include version): Ubuntu 23.04
* Any other relevant environment information: Used gnome-42-2204 from the stable branch (68)

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings

## Other Info:
Please check the permissions for this repo since I didn't have the ability to push directly like I can for other github.com/ubuntu Snaps.