### PR TITLE
add libsystemd-dev to build dependencies

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -48,6 +48,8 @@ parts:
     meson-parameters:
       - --prefix=/usr
       - --buildtype=release
+    build-packages:
+      - libsystemd-dev
 
   # Find files provided by the base and platform snap and ensure they aren't
   # duplicated in this snap


### PR DESCRIPTION
the snap builds but it has a dependency on the new libadwaita provided by gnome-42-2204
There might be a change in progress to add libsystemd-dev to gnome-sdk so this request might become obsolete by then