### PR TITLE
Update to 48.0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,11 +34,11 @@ parts:
   gnome-font-viewer:
     source: https://gitlab.gnome.org/GNOME/gnome-font-viewer.git
     source-type: git
-    source-tag: '45.0'
+    source-tag: '48.0'
     source-depth: 1
 # ext:updatesnap
 #   version-format:
-#     lower-than: '46'
+#     lower-than: '49'
 #     no-9x-revisions: true
     parse-info: [usr/share/metainfo/org.gnome.font-viewer.appdata.xml]
     override-pull: |


### PR DESCRIPTION
Upstream bumped the libadwaita requirement to 1.5 which is available in the 46 sdk. The update is building and working fine locally